### PR TITLE
Fix segmentation fault due to bad balancing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 /tests/kdtree2_test
 /tests/kdtree_test
 /tests/kdtree2_test_openmp
+/tests/kdtree2_test_scale

--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,16 @@ endif
 
 # Compiler flags
 ifeq ($(F90), ifort)
-	FFLAGS := -warn all -O3 -qopenmp -fno-alias -module $(BUILD_DIR)
+	FFLAGS := -warn all -O3 -qopenmp -fno-alias -module $(BUILD_DIR) -g
 	ifeq ($(DEBUG), 1)
-		FFLAGS += -g -check all -traceback
+		FFLAGS += -check all -traceback
 	endif
 endif
 
 ifeq ($(F90), gfortran)
-	FFLAGS := -Wall -O3 -fopenmp -J $(BUILD_DIR)
+	FFLAGS := -Wall -O3 -fopenmp -J $(BUILD_DIR) -g
 	ifeq ($(DEBUG), 1)
-		FFLAGS += -g -fcheck=all
+		FFLAGS += -fcheck=all
 	endif
 endif
 

--- a/src/kdtree2_module.f90
+++ b/src/kdtree2_module.f90
@@ -276,9 +276,9 @@ contains
     type(kdtree2), intent(inout)         :: tp
     type(tree_node), pointer, intent(in) :: parent
     integer, intent(In)                  :: l, u
-    integer                              :: i, c, m, dimen
+    integer                              :: i, c, m, dimen, n_below_average
     logical                              :: recompute
-    real(kdkind)                         :: average
+    real(kdkind)                         :: average, balance
 
     ! first compute min and max
     dimen = tp%dimen
@@ -333,22 +333,18 @@ contains
       ! c is the identity of which coordinate has the greatest spread.
       c = maxloc(res%box(1:dimen)%upper - res%box(1:dimen)%lower, 1)
 
-      if (.false.) then
-        ! select exact median to have fully balanced tree.
+      ! Determine arithmetic average
+      average = sum(tp%input_data(c, tp%ind(l:u)))/real(u - l + 1, kdkind)
+
+      ! Determine how balanced a split on the average would be
+      n_below_average = count(tp%input_data(c, tp%ind(l:u)) < average)
+      balance = n_below_average / real(u - l + 1, kdkind)
+
+      if (balance < 0.25_kdkind .or. balance > 0.75_kdkind) then
+        ! Bad balance, so select exact median to have 'perfect' balance
         m = (l + u)/2
         call select_on_coordinate(tp%input_data, tp%ind, c, m, l, u)
       else
-        ! select point halfway between min and max, as per A. Moore,
-        ! who says this helps in some degenerate cases, or
-        ! actual arithmetic average.
-        if (.true.) then
-          ! actually compute average
-          average = sum(tp%input_data(c, tp%ind(l:u)))/real(u - l + 1, kdkind)
-        else
-          average = (res%box(c)%upper + res%box(c)%lower)/2.0
-        end if
-
-        res%cut_val = average
         m = select_on_coordinate_value(tp%input_data, tp%ind, c, average, l, u)
       end if
 

--- a/tests/kdtree2_test_scale.f90
+++ b/tests/kdtree2_test_scale.f90
@@ -1,0 +1,78 @@
+! Test kdtree2 module with different point and query length scales
+program test_openmp
+  use iso_fortran_env, only: int64
+  use kdtree2_module
+
+  implicit none
+
+  type(kdtree2)                     :: tree
+  real(kdkind), allocatable         :: points(:, :)
+  real(kdkind), allocatable         :: query_points(:, :)
+  type(kdtree2_result), allocatable :: results(:)
+  integer, allocatable              :: nearest_neighbors(:, :)
+  integer                           :: n, n_dim, n_points
+  integer                           :: n_queries, n_neighbors
+  character(len=80)                 :: arg_str
+  real(kdkind)                      :: point_scale, query_scale
+  integer(int64)                    :: t_start, t_end, count_rate
+  real(kdkind)                      :: wallclock_time
+
+  if (command_argument_count() == 6) then
+     call get_command_argument(1, arg_str)
+     read(arg_str, *) n_dim
+     call get_command_argument(2, arg_str)
+     read(arg_str, *) n_points
+     call get_command_argument(3, arg_str)
+     read(arg_str, *) n_queries
+     call get_command_argument(4, arg_str)
+     read(arg_str, *) n_neighbors
+     call get_command_argument(5, arg_str)
+     read(arg_str, *) point_scale
+     call get_command_argument(6, arg_str)
+     read(arg_str, *) query_scale
+  else
+     print *, "Usage: ./kdtree2_test_scales n_dim n_points n_queries &
+          &n_neighbors point_scale query_scale"
+     n_dim = 3
+     n_points = 1000
+     n_queries = 10
+     n_neighbors = 1
+     point_scale = 1.0_kdkind
+     query_scale = 1.0_kdkind
+  end if
+
+  write(*, "(A20,I12)") "n_dim               ", n_dim
+  write(*, "(A20,I12)") "n_points            ", n_points
+  write(*, "(A20,I12)") "n_queries           ", n_queries
+  write(*, "(A20,I12)") "n_neighbors         ", n_neighbors
+  write(*, "(A20,E12.3)") "point_scale         ", point_scale
+  write(*, "(A20,E12.3)") "query_scale         ", query_scale
+
+  allocate(points(n_dim, n_points))
+  allocate(query_points(n_dim, n_queries))
+  allocate(nearest_neighbors(n_neighbors, n_queries))
+  allocate(results(n_neighbors))
+
+  call random_number(points)
+  call random_number(query_points)
+
+  points = points * point_scale
+  query_points = query_points * query_scale
+
+  tree = kdtree2_create(points, sort=.false., rearrange=.false.)
+
+  call system_clock(t_start, count_rate)
+  do n = 1, n_queries
+     call kdtree2_n_nearest(tree, query_points(:, n), n_neighbors, results)
+     nearest_neighbors(:, n) = results(:)%idx
+  end do
+  call system_clock(t_end, count_rate)
+  wallclock_time = (t_end-t_start) / real(count_rate, kdkind)
+
+  write(*, "(A20,E12.3,A)") "Wallclock-seq.      ", wallclock_time
+  write(*, "(A20,E12.3,A)") "Queries/s-seq.      ", n_queries/wallclock_time
+
+  call kdtree2_destroy(tree)
+  deallocate(points, query_points, nearest_neighbors, results)
+
+end program test_openmp


### PR DESCRIPTION
This bug has been present in the library for many years. When creating a tree with identical points, the default splitting algorithm would put all points on one side, since it splits by less or more than the average coordinate. This would then lead to a segmentation fault, because the recursive splitting does not end.

The improved code checks whether the balance is < 0.25 or > 0.75, and in such cases reverts to the other algorithm already present in the library (but previously disabled), which splits into 50/50 balanced sides.

Furthermore, I have added a test case where the scale for the points and query points can be modified. By scaling the points with zero, it can be tested that a segmentation fault no longer occurs. Finally, the `-g` flag was added to the default flags, since this does not harm performance and makes debugging symbols available, which is often convenient.